### PR TITLE
POST: api/category テスト仕様書と相違によるデバッグ

### DIFF
--- a/inventory-bk/src/main/java/inventory/example/inventory_id/request/CategoryRequest.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/request/CategoryRequest.java
@@ -1,12 +1,15 @@
 package inventory.example.inventory_id.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class CategoryRequest {
+  private final String nonEmptyStringRegex = ".*[^\\s　].*";
   @NotBlank(message = "カテゴリ名は必須")
   @Size(max = 50, message = "カテゴリ名は50文字以内")
+  @Pattern(regexp = nonEmptyStringRegex, message = "カテゴリ名は必須")
   private String name;
 }

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/controller/CategoryControllerTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/controller/CategoryControllerTest.java
@@ -4,8 +4,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -36,6 +36,7 @@ import org.springframework.web.server.ResponseStatusException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import inventory.example.inventory_id.dto.CategoryDto;
+import inventory.example.inventory_id.exception.ValidationException;
 import inventory.example.inventory_id.model.Category;
 import inventory.example.inventory_id.model.Item;
 import inventory.example.inventory_id.request.CategoryRequest;
@@ -60,8 +61,10 @@ class CategoryControllerTest {
 
   @BeforeEach
   void setUp() {
-    doReturn(testUserId).when(categoryController).fetchUserIdFromToken();
-    mockMvc = MockMvcBuilders.standaloneSetup(categoryController).build();
+    lenient().doReturn(testUserId).when(categoryController).fetchUserIdFromToken();
+    mockMvc = MockMvcBuilders.standaloneSetup(categoryController)
+        .setControllerAdvice(new ValidationException())
+        .build();
   }
 
   @Test
@@ -159,6 +162,19 @@ class CategoryControllerTest {
         .content(objectMapper.writeValueAsString(req)))
         .andExpect(status().isConflict())
         .andExpect(content().json("{\"message\":\"カテゴリー名はすでに存在します\"}"));
+  }
+
+  @Test
+  @Tag("POST: /api/category")
+  @DisplayName("カテゴリー作成-失敗 400 カテゴリー名が空文字")
+  void createCategory_badRequest_nameEmpty() throws Exception {
+    CategoryRequest req = new CategoryRequest();
+    req.setName("　　　　　　"); // 空文字
+    mockMvc.perform(post("/api/category")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().json("{\"error\":\"カテゴリ名は必須\"}"));
   }
 
   @Test


### PR DESCRIPTION
### 修正内容

テストケース：
TC-3-009 : カテゴリ名が全角と半角のスペースだけ作成できないこと
TC-4-008 : カテゴリ名が全角と半角のスペースだけ作成できないこと

対応法：
全角と半角のスペースのパターンをバリデーション追加

対応コミット：
[カテゴリ名が全角と半角のスペースのバリデーション追加](https://github.com/ryk2025/inventory-java/commit/a5c7d0a94a8e182c10862acee6db83bbcf0b6842)


結果：
<img width="1439" height="948" alt="TC-3-009" src="https://github.com/user-attachments/assets/9b499a15-bafc-4ea6-820f-b16a3e62f921" />

テスト仕様書リンク：
https://docs.google.com/spreadsheets/d/1gGgk1tv9w9KVVBZ3_Ay6l81I8m5iN9pzfr-teeWAu6Y/edit?gid=1471121681#gid=1471121681