### PR TITLE
GET: api/category テスト仕様書と相違によるデバッグ

### DIFF
--- a/inventory-bk/src/main/java/inventory/example/inventory_id/controller/CategoryController.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/controller/CategoryController.java
@@ -34,6 +34,8 @@ public class CategoryController extends BaseController {
       String userId = fetchUserIdFromToken();
       List<CategoryDto> categories = categoryService.getAllCategories(userId);
       return response(HttpStatus.OK, categories);
+    } catch (ResponseStatusException e) {
+      return response(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
     } catch (Exception e) {
       return response(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }

--- a/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
@@ -29,7 +29,11 @@ public class CategoryService {
 
   public List<CategoryDto> getAllCategories(String userId) {
     // ユーザとデフォルトのカテゴリを取得
-    return categoryRepository.findNotDeleted(List.of(userId, systemUserId)).stream()
+    List<Category> categories = categoryRepository.findNotDeleted(List.of(userId, systemUserId));
+    if (categories.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, categoryNotFoundMsg);
+    }
+    return categories.stream()
         .sorted(Comparator.comparing(Category::getName))
         .map(category -> new CategoryDto(category.getName()))
         .toList();

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/controller/CategoryControllerTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/controller/CategoryControllerTest.java
@@ -78,6 +78,20 @@ class CategoryControllerTest {
 
   @Test
   @Tag("GET: /api/category")
+  @DisplayName("カテゴリー一覧取得-404 カテゴリーがゼロ件")
+  void fetchAllCategories_throws404() throws Exception {
+    when(categoryService.getAllCategories(anyString()))
+        .thenThrow(new ResponseStatusException(
+            HttpStatus.NOT_FOUND,
+            categoryNotFoundMsg));
+
+    mockMvc.perform(get("/api/category"))
+        .andExpect(status().isNotFound())
+        .andExpect(content().json("{\"message\":\"" + categoryNotFoundMsg + "\"}"));
+  }
+
+  @Test
+  @Tag("GET: /api/category")
   @DisplayName("カテゴリー一覧取得-500 サーバーエラー")
   void fetchAllCategories_throws500() throws Exception {
     when(categoryService.getAllCategories(anyString())).thenThrow(new RuntimeException(serverErrorMsg));

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -82,9 +83,11 @@ public class CategoryServiceTest {
     String userId = testUserId;
     when(categoryRepository.findNotDeleted(List.of(userId, defaultSystemId)))
         .thenReturn(List.of());
-
-    List<CategoryDto> result = categoryService.getAllCategories(userId);
-    assertTrue(result.isEmpty());
+    ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+      categoryService.getAllCategories(userId);
+    });
+    assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+    assertEquals(categoryNotFoundMsg, exception.getReason());
   }
 
   @Test


### PR DESCRIPTION
### 修正内容

テストケース：
TC-1-003 : カテゴリー取得がゼロ件のエラー

対応法：
カテゴリーの取得件数がゼロ件時にエラーを投げます

対応コミット：
[カテゴリー取得がゼロ件の対応](https://github.com/ryk2025/inventory-java/commit/a5c00c447fa5f23acf67faea1d6b3898aab21de0)


結果：
<img width="2121" height="1312" alt="TC-1-003" src="https://github.com/user-attachments/assets/d4480637-3ff6-42a5-834c-80d50c7b3eec" />


テスト仕様書リンク：
https://docs.google.com/spreadsheets/d/1gGgk1tv9w9KVVBZ3_Ay6l81I8m5iN9pzfr-teeWAu6Y/edit?gid=0#gid=0