### PR TITLE
DELETE: api/category テスト仕様書と相違によるデバッグ

### DIFF
--- a/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
@@ -98,7 +98,7 @@ public class CategoryService {
         .findFirst()
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, categoryNotFoundMsg));
 
-    if (category.getUserId() != userId) {
+    if (!category.getUserId().equals(userId)) {
       throw new IllegalArgumentException("デフォルトカテゴリは削除できません");
     }
     if (category.getItems().isEmpty()) {

--- a/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
@@ -101,7 +101,8 @@ public class CategoryService {
     if (!category.getUserId().equals(userId)) {
       throw new IllegalArgumentException("デフォルトカテゴリは削除できません");
     }
-    if (category.getItems().isEmpty()) {
+    if (category.getItems().isEmpty() ||
+        category.getItems().stream().allMatch(item -> item.isDeletedFlag())) {
       // アイテムが存在しない場合のみ削除フラグを立てる
       category.setDeletedFlag(true);
       categoryRepository.save(category);

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
@@ -330,9 +330,8 @@ public class CategoryServiceTest {
   void testDeleteCategorySuccess() {
     UUID categoryId = UUID.randomUUID();
     String userId = testUserId;
-    Category category = new Category();
+    Category category = new Category("ToBeDeleted", new String(userId));
     category.setId(categoryId);
-    category.setUserId(userId);
     category.setItems(new ArrayList<>());
     when(categoryRepository.findNotDeleted(List.of(userId, defaultSystemId)))
         .thenReturn(List.of(category));

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
@@ -332,6 +332,23 @@ public class CategoryServiceTest {
     String userId = testUserId;
     Category category = new Category("ToBeDeleted", new String(userId));
     category.setId(categoryId);
+    category.setItems(new ArrayList<Item>());
+
+    when(categoryRepository.findNotDeleted(List.of(userId, defaultSystemId)))
+        .thenReturn(List.of(category));
+
+    assertDoesNotThrow(() -> categoryService.deleteCategory(categoryId, userId));
+    assertTrue(category.isDeletedFlag());
+  }
+
+  @Test
+  @Tag("deleteCategory")
+  @DisplayName("カテゴリー削除成功- 削除したアイテムが存在する場合")
+  void testDeleteCategorySuccessWithDeletedItems() {
+    UUID categoryId = UUID.randomUUID();
+    String userId = testUserId;
+    Category category = new Category("ToBeDeleted", new String(userId));
+    category.setId(categoryId);
     category.setItems(new ArrayList<Item>(List.of(new Item(
         "DeletedItem",
         new String(userId),

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
@@ -332,7 +332,13 @@ public class CategoryServiceTest {
     String userId = testUserId;
     Category category = new Category("ToBeDeleted", new String(userId));
     category.setId(categoryId);
-    category.setItems(new ArrayList<>());
+    category.setItems(new ArrayList<Item>(List.of(new Item(
+        "DeletedItem",
+        new String(userId),
+        category,
+        1,
+        true))));
+
     when(categoryRepository.findNotDeleted(List.of(userId, defaultSystemId)))
         .thenReturn(List.of(category));
 


### PR DESCRIPTION
### 修正内容

テストケース：
TC-5-001 カテゴリーの削除

対応法：
UserIdのタイプがString に変更したため、IDを比較する時は＝＝からString.equalsに変更

対応コミット：
[削除できないための修正](https://github.com/ryk2025/inventory-java/commit/6c31c270245b765b0b7119bf494b4fa2ced32fbd)


結果：
<img width="2121" height="1312" alt="TC-5-001" src="https://github.com/user-attachments/assets/b787c205-14d8-4a24-b6c1-018a57019372" />



テスト仕様書リンク：
https://docs.google.com/spreadsheets/d/1gGgk1tv9w9KVVBZ3_Ay6l81I8m5iN9pzfr-teeWAu6Y/edit?gid=982365622#gid=982365622