### PR TITLE
PUT: api/category テスト仕様書と相違によるデバッグ

### DIFF
--- a/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/service/CategoryService.java
@@ -74,7 +74,7 @@ public class CategoryService {
       throw new IllegalArgumentException(categoryNotFoundMsg);
     }
     Category category = categoryOpt.get();
-    if (category.getUserId() != userId) {
+    if (!category.getUserId().equals(userId)) {
       throw new IllegalArgumentException("デフォルトカテゴリは編集できません");
     }
     List<Category> exsitCategory = categoryRepository

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
@@ -249,8 +249,8 @@ public class CategoryServiceTest {
     request.setName("UpdatedName");
     String userId = testUserId;
 
-    Category category = new Category("OldName");
-    category.setUserId(userId);
+    Category category = new Category("OldName", new String(testUserId));
+
     when(categoryRepository.findUserCategory(List.of(userId, defaultSystemId), categoryId))
         .thenReturn(Optional.of(category));
     when(categoryRepository.save(any(Category.class))).thenReturn(category);
@@ -308,13 +308,12 @@ public class CategoryServiceTest {
     request.setName("Update");
     String userId = testUserId; // Default user ID
 
-    Category category = new Category("target");
-    category.setUserId(defaultSystemId);
-    category.setUserId(userId);
+    Category category = new Category("target", new String(userId));
+
     when(categoryRepository.findUserCategory(List.of(userId, defaultSystemId), categoryId))
         .thenReturn(Optional.of(category));
     when(categoryRepository.findActiveCateByName(List.of(userId, defaultSystemId), request.getName()))
-        .thenReturn(List.of(new Category(request.getName())));
+        .thenReturn(List.of(new Category(request.getName(), new String(userId))));
 
     ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
       categoryService.updateCategory(categoryId, request, userId);


### PR DESCRIPTION
### 修正内容

テストケース：
TC-4-001: カテゴリーの更新
TC-4-002: カテゴリ名が50字の更新の場合

対応法：
UserIdのタイプがString に変更したため、IDを比較する時は＝＝からString.equalsに変更

対応コミット：
[カテゴリ更新できないための修正](https://github.com/ryk2025/inventory-java/pull/18/commits/ddef43abeaaa7577799175e98db65f970d477079)


結果：
<img width="2121" height="1312" alt="TC-4-001" src="https://github.com/user-attachments/assets/def8dd4e-70cd-459a-9746-b0914dc22c82" />
<img width="2121" height="1312" alt="TC-4-002" src="https://github.com/user-attachments/assets/4c174286-5ddd-4d83-b033-23c64b2e5976" />



テスト仕様書リンク：
https://docs.google.com/spreadsheets/d/1gGgk1tv9w9KVVBZ3_Ay6l81I8m5iN9pzfr-teeWAu6Y/edit?gid=1447165993#gid=1447165993