### PR TITLE
GET: api/category/item テスト仕様書と相違によるデバッグ

### DIFF
--- a/inventory-bk/src/main/java/inventory/example/inventory_id/controller/CategoryController.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/controller/CategoryController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import inventory.example.inventory_id.dto.CategoryDto;
-import inventory.example.inventory_id.model.Item;
+import inventory.example.inventory_id.dto.ItemDto;
 import inventory.example.inventory_id.request.CategoryRequest;
 import inventory.example.inventory_id.service.CategoryService;
 import jakarta.validation.Valid;
@@ -43,7 +43,7 @@ public class CategoryController extends BaseController {
   public ResponseEntity<Object> getCategoryItems(@RequestParam UUID categoryId) {
     try {
       String userId = fetchUserIdFromToken();
-      List<Item> items = categoryService.getCategoryItems(userId, categoryId);
+      List<ItemDto> items = categoryService.getCategoryItems(userId, categoryId);
       return response(HttpStatus.OK, items);
     } catch (Exception e) {
       return response(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());

--- a/inventory-bk/src/main/java/inventory/example/inventory_id/model/Item.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/model/Item.java
@@ -63,4 +63,19 @@ public class Item {
     this.quantity = quantity;
     this.deletedFlag = deletedFlag;
   }
+
+  public Item(
+      String name,
+      String userId,
+      Category category,
+      int quantity,
+      boolean deletedFlag,
+      LocalDateTime updatedAt) {
+    this.name = name;
+    this.userId = userId;
+    this.category = category;
+    this.quantity = quantity;
+    this.deletedFlag = deletedFlag;
+    this.updatedAt = updatedAt;
+  }
 }

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/controller/CategoryControllerTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/controller/CategoryControllerTest.java
@@ -36,8 +36,8 @@ import org.springframework.web.server.ResponseStatusException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import inventory.example.inventory_id.dto.CategoryDto;
+import inventory.example.inventory_id.dto.ItemDto;
 import inventory.example.inventory_id.model.Category;
-import inventory.example.inventory_id.model.Item;
 import inventory.example.inventory_id.request.CategoryRequest;
 import inventory.example.inventory_id.service.CategoryService;
 
@@ -92,7 +92,7 @@ class CategoryControllerTest {
   @DisplayName("カテゴリーアイテム取得-200 OK")
   void getCategoryItems_returnsItems() throws Exception {
     UUID categoryId = UUID.randomUUID();
-    List<Item> items = Arrays.asList(new Item(), new Item());
+    List<ItemDto> items = Arrays.asList(new ItemDto(), new ItemDto());
     when(categoryService.getCategoryItems(anyString(), any(UUID.class))).thenReturn(items);
     mockMvc.perform(get("/api/category/items").param("categoryId", categoryId.toString()))
         .andExpect(status().isOk())

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/service/CategoryServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 import inventory.example.inventory_id.dto.CategoryDto;
+import inventory.example.inventory_id.dto.ItemDto;
 import inventory.example.inventory_id.model.Category;
 import inventory.example.inventory_id.model.Item;
 import inventory.example.inventory_id.repository.CategoryRepository;
@@ -93,16 +95,27 @@ public class CategoryServiceTest {
   void testGetCategoryItemsSuccess() {
     UUID categoryId = UUID.randomUUID();
     String userId = testUserId;
-    Category category = new Category();
+    String otherUserId = "otherUserId";
+    Category category = new Category("TestCategory", defaultSystemId);
     category.setId(categoryId);
-    category.setUserId(userId);
-    category.setItems(List.of(new Item("Item1")));
+
+    LocalDateTime now = LocalDateTime.now();
+
+    Item userNewItem = new Item("userNewItem", userId, category, 10, false, now);
+    Item userOldItem = new Item("userOldItem", userId, category, 8, false, now.minusDays(1));
+    Item userDeletedItem = new Item("userDeletedItem", userId, category, 8, true, now.minusDays(1));
+
+    Item otherUserItem = new Item("otherUserItem", otherUserId, category, 5, false);
+
+    category.setItems(new ArrayList<>(List.of(userNewItem,
+        userOldItem, userDeletedItem, otherUserItem)));
     when(categoryRepository.findNotDeleted(List.of(userId, defaultSystemId)))
         .thenReturn(List.of(category));
 
-    List<Item> result = categoryService.getCategoryItems(testUserId, categoryId);
-    assertFalse(result.isEmpty());
-    assertEquals(category.getItems(), result);
+    List<ItemDto> result = categoryService.getCategoryItems(testUserId, categoryId);
+    assertEquals(2, result.size());
+    assertEquals("userNewItem", result.get(0).getName());
+    assertEquals("userOldItem", result.get(1).getName());
   }
 
   @Test
@@ -111,13 +124,13 @@ public class CategoryServiceTest {
   void testGetCategoryItemsEmpty() {
     UUID categoryId = UUID.randomUUID();
     String userId = testUserId;
-    Category category = new Category();
+    Category category = new Category("TestCategory", new String(userId));
     category.setId(categoryId);
-    category.setUserId(userId);
+    category.setItems(new ArrayList<>());
     when(categoryRepository.findNotDeleted(List.of(userId, defaultSystemId)))
         .thenReturn(List.of(category));
 
-    List<Item> result = categoryService.getCategoryItems(testUserId, categoryId);
+    List<ItemDto> result = categoryService.getCategoryItems(testUserId, categoryId);
     assertTrue(result.isEmpty());
   }
 


### PR DESCRIPTION
### 修正内容

テストケース：
TC-2-001: 
- アイテム一覧の取得
- アイテムの並びは最新登録時間順で並びこと
- 他のユーザとは干渉しないこと
- 削除したアイテムは表示されないこと

対応法：
ItemをDtoに変換して、必要な値だけを返す

対応コミット：
[アイテムリストの形式がDtoに変換しなかったための修正](https://github.com/ryk2025/inventory-java/commit/bd9fc94e25d592b1304069804a16b30e17f65525)


結果：
<img width="2121" height="1312" alt="TC-2-001" src="https://github.com/user-attachments/assets/75fe5a7e-a6e4-4eaf-8f7e-aa4dc994158f" />




テスト仕様書リンク：
https://docs.google.com/spreadsheets/d/1gGgk1tv9w9KVVBZ3_Ay6l81I8m5iN9pzfr-teeWAu6Y/edit?gid=864830075#gid=864830075