### PR TITLE
POST: api/tem テスト仕様書と相違によるデバッグ

### DIFF
--- a/inventory-bk/src/main/java/inventory/example/inventory_id/service/ItemService.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/service/ItemService.java
@@ -46,7 +46,9 @@ public class ItemService {
 
     // 同じ名前のアイテムが存在し、削除されていない場合はエラーを投げる
     cate.getItems().stream()
-        .filter(i -> i.getName().equals(itemRequest.getName()) && !i.isDeletedFlag())
+        .filter(i -> i.getName()
+            .equals(itemRequest.getName()) && !i.isDeletedFlag()
+            && i.getUserId().equals(userId))
         .findAny()
         .ifPresent(i -> {
           throw new ResponseStatusException(HttpStatus.CONFLICT,


### PR DESCRIPTION
### 修正内容

テストケース：
TC-2-001: 
- 別ユーザが作成したアイテムと同じカテゴリーと名前を作成する場合

対応法：
userIDにフィルターをかけることで、操作してるユーザだけのアイテムを取得する

対応コミット：
[アイテム作成時ユーザをフィルターしていないため修正](https://github.com/ryk2025/inventory-java/commit/ffef957e790721ff742ecc8e81f1994b271eb09b)


結果：
<img width="2121" height="1312" alt="スクリーンショット 2025-09-09 11 03 34" src="https://github.com/user-attachments/assets/9d468133-9fd1-4c81-907d-c3512f543e6f" />




テスト仕様書リンク：
https://docs.google.com/spreadsheets/d/1gGgk1tv9w9KVVBZ3_Ay6l81I8m5iN9pzfr-teeWAu6Y/edit?gid=2140989658#gid=2140989658