### PR TITLE
アイテムの更新と作成のテストケース追加

### DIFF
--- a/inventory-bk/src/test/java/inventory/example/inventory_id/controller/ItemControllerTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/controller/ItemControllerTest.java
@@ -82,6 +82,20 @@ class ItemControllerTest {
 
   @Test
   @Tag("POST: /api/item")
+  @DisplayName("アイテム作成-201 数量が入力されていない場合も作成できる")
+  void createItem_badRequest_quantityMissing() throws Exception {
+    ItemRequest req = new ItemRequest();
+    req.setCategoryName("category");
+    req.setName("itemName");
+    mockMvc.perform(post("/api/item")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isCreated())
+        .andExpect(content().json("{\"message\":\"アイテムの作成が完了しました\"}"));
+  }
+
+  @Test
+  @Tag("POST: /api/item")
   @DisplayName("アイテム作成-400 Bad Request カテゴリーが見つからない")
   void createItem_badRequest_categoryNotFound() throws Exception {
     ItemRequest req = new ItemRequest("itemName", "category", 1);

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/controller/ItemControllerTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/controller/ItemControllerTest.java
@@ -246,6 +246,26 @@ class ItemControllerTest {
         .andExpect(content().json("{\"message\":\"アイテムの更新が完了しました\"}"));
   }
 
+  @Tag("PUT: /api/item")
+  @DisplayName("アイテム更新-200 数量が入力されていない場合も更新できる")
+  void updateItem_successWithoutQuantity() throws Exception {
+    UUID itemId = UUID.randomUUID();
+    ItemRequest req = new ItemRequest();
+    req.setName("itemName");
+    req.setCategoryName("category");
+
+    doNothing().when(itemService).updateItem(
+        anyString(),
+        eq(itemId),
+        any(ItemRequest.class));
+    mockMvc.perform(put("/api/item")
+        .param("item_id", itemId.toString())
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(req)))
+        .andExpect(status().isOk())
+        .andExpect(content().json("{\"message\":\"アイテムの更新が完了しました\"}"));
+  }
+
   @Test
   @Tag("PUT: /api/item")
   @DisplayName("アイテム更新-404 Not Found アイテムが見つかりません")


### PR DESCRIPTION
## 実装内容

### 理由

アイテム作成と更新際ににリクエストはquantityが入力しない場合のテストケースは欠けているため。

### 実装

- itemのserviceに上記のテストケースを追加。
- itemのcontrollerに上記のテストケース追加。