### PR TITLE
アイテムにカテゴリの更新は可能ように機能実装

### DIFF
--- a/inventory-bk/src/main/java/inventory/example/inventory_id/repository/ItemRepository.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/repository/ItemRepository.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import org.springframework.stereotype.Repository;
 
 import inventory.example.inventory_id.model.Item;
@@ -38,4 +37,16 @@ public interface ItemRepository extends JpaRepository<Item, UUID> {
   Optional<Item> getActiveItemWithId(
       List<String> userIds,
       UUID itemId);
+
+  @Query(value = """
+      SELECT *
+      FROM item
+      WHERE user_id IN (:userIds)
+      AND name = :name
+      AND category_id = :categoryId
+      AND deleted_flag = FALSE
+      """, nativeQuery = true)
+  Optional<Item> getActiveWithSameNameAndCategory(
+      List<String> userIds,
+      String name, UUID categoryId);
 }

--- a/inventory-bk/src/main/java/inventory/example/inventory_id/service/ItemService.java
+++ b/inventory-bk/src/main/java/inventory/example/inventory_id/service/ItemService.java
@@ -88,31 +88,32 @@ public class ItemService {
       String userId,
       UUID itemId,
       ItemRequest itemRequest) {
-    // 自分とデフォルトのカテゴリーアイテムを取得
-    List<Item> items = itemRepository.getActiveByCategoryName(
-        List.of(userId, systemUserId),
-        itemRequest.getCategoryName());
-    // 編集したいアイテムを取得
-    Optional<Item> matchItem = items.stream()
-        .filter(i -> i.getId().equals(itemId))
-        .findFirst();
-    if (matchItem.isEmpty()) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, itemsNotFoundMsg);
-    }
+    // 編集するアイテムを取得
+    Item item = itemRepository.getActiveItemWithId(List.of(userId, systemUserId), itemId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, itemsNotFoundMsg));
 
-    // 編集したい名前は他のアイテムに重複かをチェック
-    List<Item> sameNamedItem = items.stream()
-        .filter(
-            i -> i.getName()
-                .equals(itemRequest.getName()) &&
-                !i.getId().equals(itemId))
-        .toList();
-    if (!sameNamedItem.isEmpty()) {
+    // リクエストのカテゴリー名からカテゴリーを取得
+    Category category = categoryRepository
+        .findActiveCateByName(List.of(userId, systemUserId), itemRequest.getCategoryName())
+        .stream()
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(categoryNotFoundMsg));
+
+    // 同じ名前のアイテムが存在し、削除されていない場合はエラーを投げる
+    Optional<Item> sameNameItem = itemRepository.getActiveWithSameNameAndCategory(
+        List.of(userId, systemUserId),
+        itemRequest.getName(),
+        category.getId());
+
+    // 同じ名前のアイテムが存在し、かつそれが自分自身でない場合はエラー
+    if (sameNameItem.isPresent() &&
+        !sameNameItem.get().getId().equals(item.getId())) {
       throw new IllegalArgumentException("アイテム名は既に登録されています");
     }
 
-    Item item = matchItem.get();
+    // アイテムの名前とカテゴリーを更新して保存
     item.setName(itemRequest.getName());
+    item.setCategory(category);
     itemRepository.save(item);
   }
 

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/repository/ItemRepositoryTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/repository/ItemRepositoryTest.java
@@ -189,4 +189,17 @@ public class ItemRepositoryTest {
     assertThat(result.get().getCategoryName()).isEqualTo(defaultCategory.getName());
     assertThat(result.get().isDeletedFlag()).isFalse();
   }
+
+  @Test
+  @DisplayName("同じ名前とカテゴリのアクティブなアイテムを取得できる- ゼロ件の場合")
+  void testGetActiveWithSameNameAndCategory_NoItem() {
+    Category defaultCategory = new Category("DefaultCategory", defaultSystemId);
+    categoryRepository.save(defaultCategory);
+
+    Optional<Item> result = itemRepository.getActiveWithSameNameAndCategory(
+        List.of(testUserId, defaultSystemId),
+        "nonexistentItemName",
+        defaultCategory.getId());
+    assertThat(result).isEmpty();
+  }
 }

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/repository/ItemRepositoryTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/repository/ItemRepositoryTest.java
@@ -141,4 +141,52 @@ public class ItemRepositoryTest {
     Optional<Item> result = itemRepository.getActiveItemWithId(List.of(defaultSystemId), UUID.randomUUID());
     assertThat(result).isEmpty();
   }
+
+  @Test
+  @DisplayName("同じ名前とカテゴリのアクティブなアイテムを取得できる, 削除済みアイテムは除外される, ユーザお互いにのアイテムは影響しない")
+  void testGetActiveWithSameNameAndCategory() {
+    String sameCategoryName = "SameCategory";
+    String sameItemName = "SameItemName";
+    Category userCategory = new Category(sameCategoryName, testUserId);
+    Category anotherUserCategory = new Category(sameCategoryName, "anotherUserId");
+    categoryRepository.saveAll(List.of(userCategory, anotherUserCategory));
+    Item userExistingItem = new Item(sameItemName, testUserId, userCategory, false);
+    Item userDeletedItem = new Item(sameItemName, testUserId, userCategory, true);
+    Item anotherUserItem = new Item(sameItemName, "anotherUserId", anotherUserCategory, false);
+
+    itemRepository.saveAll(List.of(userExistingItem, userDeletedItem, anotherUserItem));
+
+    Optional<Item> result = itemRepository.getActiveWithSameNameAndCategory(
+        List.of(testUserId, defaultSystemId),
+        sameItemName,
+        userCategory.getId());
+    assertThat(result).isPresent();
+    assertThat(result.get().getUserId()).isEqualTo(testUserId);
+    assertThat(result.get().getName()).isEqualTo(sameItemName);
+    assertThat(result.get().getCategoryName()).isEqualTo(sameCategoryName);
+    assertThat(result.get().isDeletedFlag()).isFalse();
+  }
+
+  @Test
+  @DisplayName("同じ名前とカテゴリのアクティブなアイテムを取得できる, デフォルトのカテゴリ使用するもユーザお互いに影響しない")
+  void testGetActiveWithSameNameAndDefaultCategory() {
+    Category defaultCategory = new Category("DefaultCategory", defaultSystemId);
+    categoryRepository.save(defaultCategory);
+    String sameItemName = "sameItemName";
+    Item userExistingItem = new Item(sameItemName, testUserId, defaultCategory, false);
+    Item userDeletedItem = new Item(sameItemName, testUserId, defaultCategory, true);
+    Item anotherUserItem = new Item(sameItemName, "anotherUserId", defaultCategory, false);
+
+    itemRepository.saveAll(List.of(userExistingItem, userDeletedItem, anotherUserItem));
+
+    Optional<Item> result = itemRepository.getActiveWithSameNameAndCategory(
+        List.of(testUserId, defaultSystemId),
+        sameItemName,
+        defaultCategory.getId());
+    assertThat(result).isPresent();
+    assertThat(result.get().getUserId()).isEqualTo(testUserId);
+    assertThat(result.get().getName()).isEqualTo(sameItemName);
+    assertThat(result.get().getCategoryName()).isEqualTo(defaultCategory.getName());
+    assertThat(result.get().isDeletedFlag()).isFalse();
+  }
 }

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/request/ItemRequestValidationTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/request/ItemRequestValidationTest.java
@@ -46,13 +46,6 @@ class ItemRequestValidationTest {
     assertFalse(violations.isEmpty());
   }
 
-  @Test
-  @DisplayName("アイテムリクエストのバリデーション失敗 - 数量が負")
-  void testNegativeQuantity() {
-    ItemRequest request = new ItemRequest("", "category");
-    Set<ConstraintViolation<ItemRequest>> violations = validator.validate(request);
-    assertFalse(violations.isEmpty());
-  }
 
   @Test
   @DisplayName("アイテムリクエストのバリデーション失敗 - カテゴリー名が空")

--- a/inventory-bk/src/test/java/inventory/example/inventory_id/service/ItemServiceTest.java
+++ b/inventory-bk/src/test/java/inventory/example/inventory_id/service/ItemServiceTest.java
@@ -287,59 +287,122 @@ class ItemServiceTest {
 
   @Test
   @Tag("updateItem")
-  @DisplayName("アイテム更新成功")
+  @DisplayName("アイテム更新成功- 正常系")
   void testUpdateItemSuccess() {
     String userId = testUserId;
     String systemUserId = defaultSystemId;
-    String categoryName = "Laptop";
-    String newItemName = "Notebook";
-    UUID itemId = UUID.randomUUID();
+    String oldCategoryName = "oldCategoryName";
+    Category oldCategory = new Category(oldCategoryName, userId);
+    String existingName = "existingItem";
+    UUID existingItemId = UUID.randomUUID();
+    Category newCategory = new Category("newCategory", userId);
 
     Item existingItem = new Item(
-        "OldName",
+        existingName,
         testUserId,
-        null,
+        oldCategory,
         false);
-    existingItem.setId(itemId);
+    existingItem.setId(existingItemId);
 
-    ItemRequest request = new ItemRequest(newItemName, categoryName);
+    ItemRequest request = new ItemRequest("newItemName", "newCategory");
 
-    List<Item> items = new ArrayList<>();
-    items.add(existingItem);
+    when(itemRepository.getActiveItemWithId(List.of(userId, systemUserId), existingItemId))
+        .thenReturn(Optional.of(existingItem));
 
-    when(itemRepository.getActiveByCategoryName(
-        List.of(userId, systemUserId), categoryName))
-        .thenReturn(items);
+    when(categoryRepository.findActiveCateByName(List.of(userId, systemUserId),
+        "newCategory"))
+        .thenReturn(List.of(newCategory));
+
+    when(itemRepository.getActiveWithSameNameAndCategory(
+        List.of(userId, systemUserId), existingName, newCategory.getId())).thenReturn(Optional.empty());
+
     when(itemRepository.save(any(Item.class))).thenReturn(existingItem);
 
-    assertDoesNotThrow(() -> itemService.updateItem(userId, itemId, request));
-    assertEquals(newItemName, existingItem.getName());
+    assertDoesNotThrow(() -> itemService.updateItem(userId, existingItemId, request));
+    assertEquals("newItemName", existingItem.getName());
+    assertEquals(newCategory, existingItem.getCategory());
     verify(itemRepository).save(existingItem);
   }
 
   @Test
   @Tag("updateItem")
-  @DisplayName("アイテム更新失敗 - アイテム名重複")
+  @DisplayName("アイテム更新失敗 - アイテム名変更時、アイテム名重複")
   void testUpdateItemNameDuplicate() {
     String userId = testUserId;
     String systemUserId = defaultSystemId;
     String categoryName = "Laptop";
-    UUID itemId = UUID.randomUUID();
 
-    Item userNotebook = new Item("Notebook");
-    userNotebook.setId(itemId);
+    Category LaptopCategory = new Category(
+        categoryName, systemUserId);
+    UUID targetItemId = UUID.randomUUID();
 
-    Item diffUserNotebook = new Item("Notebook");
-    diffUserNotebook.setId(UUID.randomUUID());
+    Item userNotebook = new Item("Notebook",
+        userId, LaptopCategory, false);
+    userNotebook.setId(UUID.randomUUID());
+
+    Item targetItem = new Item(
+        "OldName",
+        userId,
+        LaptopCategory,
+        false);
+    targetItem.setId(targetItemId);
 
     ItemRequest request = new ItemRequest("Notebook", categoryName);
 
-    List<Item> items = List.of(userNotebook, diffUserNotebook);
-    when(itemRepository.getActiveByCategoryName(List.of(userId, systemUserId), categoryName))
-        .thenReturn(items);
+    when(itemRepository.getActiveItemWithId(
+        List.of(userId, systemUserId), targetItemId))
+        .thenReturn(Optional.of(targetItem));
+
+    when(categoryRepository.findActiveCateByName(
+        List.of(userId, systemUserId), categoryName))
+        .thenReturn(List.of(LaptopCategory));
+
+    when(itemRepository.getActiveWithSameNameAndCategory(
+        List.of(userId, systemUserId),
+        request.getName(),
+        LaptopCategory.getId()))
+        .thenReturn(Optional.of(userNotebook));
 
     Exception ex = assertThrows(IllegalArgumentException.class,
-        () -> itemService.updateItem(userId, itemId, request));
+        () -> itemService.updateItem(userId, targetItemId, request));
+    assertEquals("アイテム名は既に登録されています", ex.getMessage());
+  }
+
+  @Test
+  @Tag("updateItem")
+  @DisplayName("アイテム更新失敗 - カテゴリ変更時、アイテム名重複")
+  void testUpdateItemCategoryDuplicate() {
+    String userId = testUserId;
+    String systemUserId = defaultSystemId;
+    String oldCategoryName = "oldCategoryName";
+    String newCategoryName = "newCategoryName";
+    String itemName = "itemName";
+    UUID targetItemId = UUID.randomUUID();
+    Category oldCategory = new Category(oldCategoryName, systemUserId);
+    Category newCategory = new Category(newCategoryName, systemUserId);
+
+    Item itemInOldCategory = new Item(itemName, userId, oldCategory, false);
+    itemInOldCategory.setId(targetItemId);
+
+    Item itemInNewCategory = new Item(itemName, userId, newCategory, false);
+    itemInNewCategory.setId(UUID.randomUUID());
+
+    ItemRequest request = new ItemRequest(itemName,
+        "newCategoryName");
+
+    when(itemRepository.getActiveItemWithId(List.of(userId, systemUserId), targetItemId))
+        .thenReturn(Optional.of(itemInOldCategory));
+
+    when(categoryRepository.findActiveCateByName(List.of(userId, systemUserId),
+        newCategoryName))
+        .thenReturn(List.of(newCategory));
+
+    when(itemRepository.getActiveWithSameNameAndCategory(List.of(userId, systemUserId),
+        request.getName(), newCategory.getId()))
+        .thenReturn(Optional.of(itemInNewCategory));
+
+    Exception ex = assertThrows(IllegalArgumentException.class,
+        () -> itemService.updateItem(userId, targetItemId, request));
     assertEquals("アイテム名は既に登録されています", ex.getMessage());
   }
 
@@ -349,14 +412,13 @@ class ItemServiceTest {
   void testUpdateItemNotFound() {
     String userId = testUserId;
     String systemUserId = defaultSystemId;
-    String categoryName = "Laptop";
     UUID itemId = UUID.randomUUID();
 
-    ItemRequest request = new ItemRequest("Notebook", categoryName);
+    ItemRequest request = new ItemRequest("Notebook", "Laptop");
 
     when(itemRepository
-        .getActiveByCategoryName(List.of(userId, systemUserId), categoryName))
-        .thenReturn(List.of());
+        .getActiveItemWithId(List.of(userId, systemUserId), itemId))
+        .thenReturn(Optional.empty());
 
     ResponseStatusException ex = assertThrows(ResponseStatusException.class,
         () -> itemService.updateItem(userId, itemId, request));
@@ -365,30 +427,34 @@ class ItemServiceTest {
 
   @Test
   @Tag("updateItem")
-  @DisplayName("アイテム更新失敗 - アイテムIdが見つからないエラー")
-  void testUpdateItemIdNotFound() {
+  @DisplayName("アイテム更新失敗 - カテゴリが見つからない")
+  void testUpdateItemCategoryNotFound() {
     String userId = testUserId;
     String systemUserId = defaultSystemId;
-    String categoryName = "Laptop";
     UUID itemId = UUID.randomUUID();
-    Category category = new Category(categoryName);
 
-    ItemRequest request = new ItemRequest("Notebook", categoryName);
-
-    Item existingItem = new Item(
-        "Notebook",
-        userId,
-        category,
-        false);
-    existingItem.setId(UUID.randomUUID());
+    ItemRequest request = new ItemRequest("Notebook",
+        "NotExistCategory");
 
     when(itemRepository
-        .getActiveByCategoryName(List.of(userId, systemUserId), categoryName))
-        .thenReturn(List.of(existingItem));
+        .getActiveItemWithId(List.of(userId, systemUserId),
+            itemId))
+        .thenReturn(Optional.of(new Item(
+            "Notebook",
+            userId,
+            new Category(
+                "Laptop"),
+            false)));
 
-    Exception ex = assertThrows(ResponseStatusException.class,
+    when(categoryRepository
+        .findActiveCateByName(List.of(userId,
+            systemUserId), request.getCategoryName()))
+        .thenReturn(List.of());
+
+    Exception ex = assertThrows(
+        IllegalArgumentException.class,
         () -> itemService.updateItem(userId, itemId, request));
-    assertEquals(itemsNotFoundMsg, ((ResponseStatusException) ex).getReason());
+    assertEquals(categoryNotFoundMsg, ex.getMessage());
   }
 
   @Test


### PR DESCRIPTION
## 実装内容

### 理由
[要件定義書](https://github.com/ryk2025/inventory-java/blob/5b75c954f7354d84d8acb51ad761307dcf5ff5f0/app-info/requirement(phase1).md)要件3.1に関する、アイテムをカテゴリ変更できるように機能実装

### 修正内容
- アイテムのアップデートに関する実装のロジック修正
- アップデートに周りのテストケース追加
- テスト仕様書を作成https://docs.google.com/spreadsheets/d/1ip8_M3TRhvyHEnM9gnIah0V7oyxqbUhQcagG3wr1kqU/edit?gid=1109137505#gid=1109137505

### APIに影響

- PUT: api/item/{item_id} アイテムは名前とカテゴリを変更可能になります
- 各カテゴリ内はアイテム名前重複しょうとする場合はエラーになる、改修前と一緒の挙動

### デモ

1. アイテム作成
<img width="1415" height="940" alt="スクリーンショット 2025-09-19 17 12 35" src="https://github.com/user-attachments/assets/9a3d675d-e1ad-46d0-8374-7d70713c67f6" />


2. アイテムをチェック
<img width="1415" height="940" alt="スクリーンショット 2025-09-19 17 13 05" src="https://github.com/user-attachments/assets/a665596b-97eb-4e26-83af-9790c638d02c" />

3. アイテムを更新
<img width="1415" height="940" alt="スクリーンショット 2025-09-19 17 13 42" src="https://github.com/user-attachments/assets/bbc37ead-3cb0-4b68-bf3c-e51ff4fa1f38" />

4. アイテムをチェック
<img width="1415" height="940" alt="スクリーンショット 2025-09-19 17 17 12" src="https://github.com/user-attachments/assets/ce647733-9196-4b8b-87c1-3d03e291ed33" />

<img width="1415" height="940" alt="スクリーンショット 2025-09-19 17 14 15" src="https://github.com/user-attachments/assets/9dd8f14e-598e-4b53-8f26-1f78c2579b19" />

5. 名前重複するエラー
<img width="1415" height="940" alt="スクリーンショット 2025-09-19 17 21 34" src="https://github.com/user-attachments/assets/675ed8c1-1d3a-419f-8038-2f2ed3e576e2" />



